### PR TITLE
Pass changedFiles to onStart

### DIFF
--- a/README.md
+++ b/README.md
@@ -197,7 +197,8 @@ in your build script.
 ### Pre-processing and post-processing
 
 Setting `onStart` and/or `onEnd` in a build config allows you to hook into the esbuild cycle.
-`onStart(config, changedFiles)` is called when a build starts and `onEnd(config, result)` when a build finishes.
+`onStart(config, changedFiles)` is called when a build starts and `onEnd(config, result)`
+when a build finishes.
 This works in both `-watch` mode and regular "one shot" mode.
 
 These callbacks can optionally be async (i.e. return a Promise) which estrella will await.

--- a/README.md
+++ b/README.md
@@ -197,7 +197,7 @@ in your build script.
 ### Pre-processing and post-processing
 
 Setting `onStart` and/or `onEnd` in a build config allows you to hook into the esbuild cycle.
-`onStart(config)` is called when a build starts and `onEnd(config, result)` when a build finishes.
+`onStart(config, changedFiles)` is called when a build starts and `onEnd(config, result)` when a build finishes.
 This works in both `-watch` mode and regular "one shot" mode.
 
 These callbacks can optionally be async (i.e. return a Promise) which estrella will await.

--- a/estrella.d.ts
+++ b/estrella.d.ts
@@ -61,7 +61,7 @@ export interface BuildConfig extends esbuild.BuildOptions {
   // Useful when scripting and watching files for changes.
   // If a callback returns a promise, the build process will await that promise
   // before continuing.
-  onStart? :(c :Readonly<BuildConfig>)=>Promise<void>|any
+  onStart? :(c :Readonly<BuildConfig>, f :string[])=>Promise<void>|any
   onEnd?   :(c :Readonly<BuildConfig>, r :BuildResult)=>Promise<void>|any
 
   // title is purely "ornamental" and can be used for log messages etc.

--- a/src/estrella.js
+++ b/src/estrella.js
@@ -548,7 +548,7 @@ async function build1(argv, config, addCancelCallback) {
   }
 
   // build function
-  async function build(changedFiles) {
+  async function build(changedFiles = []) {
     if (watch && config.clear) {
       clear()
     }

--- a/src/estrella.js
+++ b/src/estrella.js
@@ -548,12 +548,12 @@ async function build1(argv, config, addCancelCallback) {
   }
 
   // build function
-  async function build() {
+  async function build(changedFiles) {
     if (watch && config.clear) {
       clear()
     }
 
-    const r = onStart(config)
+    const r = onStart(config, changedFiles)
     if (r instanceof Promise) {
       await r
     }
@@ -666,7 +666,7 @@ async function build1(argv, config, addCancelCallback) {
     })
     if (files.length > 0) {
       logInfo(`${files.length} files changed: ${files.join(", ")}`)
-      build()
+      build(files)
     }
   })
   addCancelCallback(() => { watchPromise.cancel() })


### PR DESCRIPTION
Because estrella watches all JavaScript and TypeScript files on the entry points' directories automatically, it would be useful if there was a way to know which specific files changed. Considering they're already on the log, I thought they could also be available to the consumer.

In the same way that `onEnd` passes the result of the build, `onStart` could pass which files triggered that build as the second argument. That would allow us to do things like this:

```js
build({
  entry: "src/estrella.js",
  outfile: "dist/estrella.js",
  onStart(config, changedFiles) {
    if (changedFiles.includes("special.js")) {
      console.log("the special file triggered build!")
    }
  },
})
```

Didn't bump the version in the PR as I saw you were just playing around with generating builds, let me know what you prefer going forward.