### PR TITLE
Watch JSX and TSX files

### DIFF
--- a/src/estrella.js
+++ b/src/estrella.js
@@ -653,7 +653,7 @@ async function build1(argv, config, addCancelCallback) {
     config.entryPoints.map(fn => dirname(Path.resolve(Path.join(workingDirectory, fn))))
   ))
   logDebug(()=> [`watching dirs:`, srcdirs])
-  const watchPromise = watchdir(srcdirs, /\.[tj]s$/, { recursive: true }, files => {
+  const watchPromise = watchdir(srcdirs, /\.[tj]sx?$/, { recursive: true }, files => {
     // filter out any output files to avoid a loop
     files = files.filter(fn => {
       if (fn == config.outfile) {


### PR DESCRIPTION
Hello again! Incremental builds are not happening on watch mode for `jsx` and `tsx` files, even though the console reports that the file has changed and an incremental compilation started.

Adding the optional `x` to the end of the filter on the default watch function fixes this.