### PR TITLE
web-livereload example documentation update

### DIFF
--- a/examples/web-livereload/README.md
+++ b/examples/web-livereload/README.md
@@ -9,6 +9,5 @@ Open the URL printed when you run `npm start` in a web browser.
 Try making changes to the `src/app.ts` file and watch the results in the web browser.
 
 - `./build.js -w` — build in release mode with web server and watch mode
-- `./build.js -wg` — build in debug mode with web server and watch mode
 - `./build.js` — build in release mode and exit
 - `./build.js -g` — build in debug mode and exit


### PR DESCRIPTION
Hi Rasmus,

This is just a small and dumb PR. The `web-livereload` example doesn't support the `./build.js -wg` command, so I removed it from the docs.

I know I know. Not a huge improvement :)

V.