### PR TITLE
fix: 404 for esbuild types.ts

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ And that's it for basic use.
 [See the `examples` directory](examples) for more examples
 which you can use as templates for new projects.
 
-See [evanw/esbuild/lib/types.ts](https://github.com/evanw/esbuild/blob/master/lib/types.ts)
+See [evanw/esbuild/lib/shared/types.ts](https://github.com/evanw/esbuild/blob/master/lib/shared/types.ts)
 for documentation of esbuild options.
 
 


### PR DESCRIPTION
Updated url for linked types.ts source from esbuild repository.