### PR TITLE
Make esbuild an external dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ into a fully-featured CLI program with access to a
 
 ## Example use
 
-1. Add Estrella to your project: `npm install -D estrella`
+1. Add Estrella to your project: `npm install -D estrella esbuild`
 2. Create a `build.js` file in your project directory:
 
 ```js

--- a/package-lock.json
+++ b/package-lock.json
@@ -7,9 +7,6 @@
     "": {
       "version": "1.4.1",
       "license": "ISC",
-      "dependencies": {
-        "esbuild": "^0.11.0"
-      },
       "bin": {
         "estrella": "dist/estrella.js"
       },
@@ -17,6 +14,7 @@
         "@types/node": "^14.14.14",
         "@types/source-map-support": "^0.5.3",
         "chokidar": "^3.5.1",
+        "esbuild": "^0.12.17",
         "miniglob": "^0.1.2",
         "source-map-support": "^0.5.19",
         "typescript": "^4.2.3"
@@ -26,6 +24,9 @@
       },
       "optionalDependencies": {
         "fsevents": "~2.3.1"
+      },
+      "peerDependencies": {
+        "esbuild": "0.x.x"
       }
     },
     "node_modules/@types/node": {
@@ -105,9 +106,10 @@
       }
     },
     "node_modules/esbuild": {
-      "version": "0.11.20",
-      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.11.20.tgz",
-      "integrity": "sha512-QOZrVpN/Yz74xfat0H6euSgn3RnwLevY1mJTEXneukz1ln9qB+ieaerRMzSeETpz/UJWsBMzRVR/andBht5WKw==",
+      "version": "0.12.17",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.12.17.tgz",
+      "integrity": "sha512-GshKJyVYUnlSXIZj/NheC2O0Kblh42CS7P1wJyTbbIHevTG4jYMS9NNw8EOd8dDWD0dzydYHS01MpZoUcQXB4g==",
+      "dev": true,
       "hasInstallScript": true,
       "bin": {
         "esbuild": "bin/esbuild"
@@ -340,9 +342,10 @@
       }
     },
     "esbuild": {
-      "version": "0.11.20",
-      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.11.20.tgz",
-      "integrity": "sha512-QOZrVpN/Yz74xfat0H6euSgn3RnwLevY1mJTEXneukz1ln9qB+ieaerRMzSeETpz/UJWsBMzRVR/andBht5WKw=="
+      "version": "0.12.17",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.12.17.tgz",
+      "integrity": "sha512-GshKJyVYUnlSXIZj/NheC2O0Kblh42CS7P1wJyTbbIHevTG4jYMS9NNw8EOd8dDWD0dzydYHS01MpZoUcQXB4g==",
+      "dev": true
     },
     "fill-range": {
       "version": "7.0.1",

--- a/package.json
+++ b/package.json
@@ -36,8 +36,8 @@
   "engines": {
     "node": ">=12.0.0"
   },
-  "dependencies": {
-    "esbuild": "^0.11.0"
+  "peerDependencies": {
+    "esbuild": "0.x.x"
   },
   "optionalDependencies": {
     "fsevents": "~2.3.1"
@@ -46,6 +46,7 @@
     "@types/node": "^14.14.14",
     "@types/source-map-support": "^0.5.3",
     "chokidar": "^3.5.1",
+    "esbuild": "^0.12.17",
     "miniglob": "^0.1.2",
     "source-map-support": "^0.5.19",
     "typescript": "^4.2.3"


### PR DESCRIPTION
It's common practice to mark the fundamental dependencies as external, thus allowing the user to specify its version.

This PR marks `esbuild` as a `peerDependency`, so they user can install it directly and specify the version.